### PR TITLE
Removed (most) sets and Venn diagrams from Chapter 1

### DIFF
--- a/source/language_logic_rules_fallacies.ptx
+++ b/source/language_logic_rules_fallacies.ptx
@@ -22,7 +22,7 @@
 <subsection>
 	<title>Logical Fallacies</title>
 	<p>
-		In the last section we saw that logical arguments are invalid when the premises are not sufficient to guarantee the conclusion, and that even if an argument is valid it may be unsound if the premises are not true. There are other ways that a logical argument my by invalid or unsound. One of the more common ways this can occur is if the argument is a <alert>fallacy</alert>.
+		In the last section we saw that logical arguments are invalid when the premises are not sufficient to guarantee the conclusion, and that even if an argument is valid it may be unsound if the premises are not true. There are other ways that a logical argument might be invalid or unsound. One of the more common ways this can occur is if the argument is a <alert>fallacy</alert>.
 	</p>
 	<p>
 		A <alert>fallacy</alert> is a type of argument that appears valid but uses a logical error to persuade or deceive. Fallacious arguments are especially common in advertising and politics, so it is important as informed citizens to recognize when we are being presented with a fallacious argument and to not be persuaded by it.

--- a/source/language_logic_rules_review.ptx
+++ b/source/language_logic_rules_review.ptx
@@ -535,7 +535,7 @@
 	</solution>
 </exercise>
 
-<exercise><!--  #8 -->
+<!-- <exercise>
 	<statement>
 	<p>
 		The following Venn Diagram shows how 70 customers at the local coffee shop like their coffee.
@@ -605,9 +605,9 @@
 		</ol>
 	</p>
 	</solution>
-</exercise>
+</exercise> 
 
-<exercise><!--  #9 -->
+<exercise>
 	<statement>
 	<p>
 		In a group of 30 students at PCC, 21 have Biology this term, 12 have Math 105 and 7 are studying both Biology and Math 105.
@@ -650,7 +650,7 @@
 	</solution>
 </exercise>
 
-<exercise><!--  #10 -->
+<exercise>
 	<statement>
 	<p>
 		The following data was collected at a local coffee shop. 120 customers were asked if they like coffee and chocolate. The results are in the table below.
@@ -685,9 +685,9 @@
 			</image>
 		</sidebyside>
 	</solution>
-</exercise>
+</exercise> 
 
-<exercise><!--  #11 -->
+<exercise>
 	<statement>
 	<p>
 		A 120 people were surveyed and it reveals the following results about how people learn about news events happening around the world.
@@ -799,7 +799,7 @@
 		</ol>
 	</p>
 	</solution>
-</exercise>
+</exercise> -->
 
 <!-- <exercisegroup>
 	<introduction>


### PR DESCRIPTION
Sets and Venn diagrams have been removed (commented out) from Chapter 1.  However, sets still appear as a visual tool for understanding deductive arguments.  These show up in Example 1.2.6, Section 1.2 Exercises 13-20, and Section 1.4 Exercises 8-10.  Please let me know if I should comment those out.

Also, fixed typo in Fallacies section.